### PR TITLE
install.sh CONDA_BASE string fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PARENT_DIR="$(dirname "$SCRIPT_DIR")"
 
 # Get conda base path early so we can use it as the default env path
-CONDA_BASE=$($CONDA_CMD info --base)
+CONDA_BASE="$("$CONDA_CMD" info --base 2>/dev/null | tail -n 1 | awk '{print $NF}')"
 
 # Function to prompt the user for the Miniforge/conda home directory.
 # The environment is always named "manifeel" and will be created at


### PR DESCRIPTION
 install.sh currently gets CONDA_BASE like this:
CONDA_BASE=$($CONDA_CMD info --base)

On the cluster, `mamba info --base`  returns:
" base environment : /scratch/.../miniforge3"
rather than,
"/scratch/.../miniforge3"

which causes an error like this due to incorrect path formatting:
```
install.sh: line 84: base environment : /scratch/gilbreth/halchaer/projects/manifeel-master/miniforge3/etc/profile.d/conda.sh: No such file or directory
```

Suggested Fix:
CONDA_BASE="$("$CONDA_CMD" info --base 2>/dev/null | tail -n 1 | awk '{print $NF}')"

This makes the parsing more robust by extracting the final field (the actual path), while still working when the command returns just the path.