### PR TITLE
Isaac Lab env_runner as drop in replacement for Isaac Gym backend

### DIFF
--- a/IsaacLab_setup_documentation.md
+++ b/IsaacLab_setup_documentation.md
@@ -1,0 +1,104 @@
+## Isaac Lab Setup
+
+Isaac Lab backend (`IsaacLabRunner`) can be used as a drop-in replacement for Isaac Gym. It uses the same `BaseImageRunner` interface so existing training code works unchanged.
+
+### Isaac Lab GitHub Clone Required
+
+The PyPI `isaaclab` package is **only a launcher stub**. It does not ship the actual framework source code (`isaaclab.envs`, `isaaclab.managers`, etc.). You must also clone the GitHub repo:
+
+```bash
+git clone https://github.com/isaac-sim/IsaacLab.git --branch v2.1.0 --depth 1 \
+    /scratch/<user>/git/IsaacLab
+```
+
+### Isaac Lab Requires Python >=3.10, so you need to make a new environment (you cannot use 3.8):
+
+```bash
+conda create --prefix /scratch/<user>/conda/envs/isaaclab python=3.10 -y
+conda activate /scratch/<user>/conda/envs/isaaclab
+
+# Fix setuptools for flatdict build
+pip install "setuptools<71"
+
+# PyTorch 2.5.1 (required by isaaclab 2.1.0)
+pip install torch==2.5.1 torchvision --index-url https://download.pytorch.org/whl/cu124
+
+# Isaac Sim 4.5.0.0 — meta-package + extensions from NVIDIA PyPI
+pip install isaacsim==4.5.0.0 --extra-index-url https://pypi.nvidia.com
+pip install \
+  isaacsim-rl==4.5.0.0 \
+  isaacsim-replicator==4.5.0.0 \
+  isaacsim-extscache-physics==4.5.0.0 \
+  isaacsim-extscache-kit-sdk==4.5.0.0 \
+  isaacsim-extscache-kit==4.5.0.0 \
+  --extra-index-url https://pypi.nvidia.com
+
+# Isaac Lab 2.1.0
+pip install isaaclab==2.1.0
+
+# ManiFeel + Diffusion Policy
+# Note: diffusion_policy uses legacy setup.py, needs compat editable mode
+pip install -e /path/to/manifeel
+cd /path/to/diffusion_policy && pip install -e . --config-settings editable_mode=compat && cd -
+
+# Remaining deps (pin numpy<2 and opencv for numpy 1.x compat)
+pip install wandb dill tqdm av "numpy<2" "opencv-python==4.9.0.80" zarr diffusers numba
+
+# gym 0.26.2 needed by MultiStepWrapper and VideoRecordingWrapper (which use 'import gym')
+pip install "gym==0.26.2"
+
+# Accept NVIDIA Omniverse EULA (one-time)
+echo "Yes" | python -c "import isaacsim"
+```
+
+> **Note on versions**: `isaaclab` 2.0.x/2.1.0 require Python 3.10 and `numpy<2`. Versions 2.2.0+ require Python 3.11 and `isaacsim>=5.0`. Always use `isaacsim` and `isaaclab` at matching major versions.
+
+### Install Isaac Lab Source Sub-Packages
+
+The GitHub source contains the actual framework. Install each sub-package from it:
+
+```bash
+ISAACLAB_GIT=/scratch/<user>/git/IsaacLab
+
+# Install the main framework (isaaclab.envs, isaaclab.managers, etc.)
+cd $ISAACLAB_GIT/source/isaaclab
+pip install -e . --config-settings editable_mode=compat --no-deps
+
+# Install task definitions (Isaac-Lift-Cube-Franka-v0, etc.)
+cd $ISAACLAB_GIT/source/isaaclab_tasks
+pip install -e . --config-settings editable_mode=compat --no-deps
+
+# Install robot assets
+cd $ISAACLAB_GIT/source/isaaclab_assets
+pip install -e . --config-settings editable_mode=compat --no-deps
+```
+
+> **Note**: Set `ISAACLAB_SOURCE` env var to point to the cloned source.
+> `IsaacLabEnvWrapper` reads this to ensure the git source takes priority over the pip launcher stub:
+> ```bash
+> export ISAACLAB_SOURCE=/scratch/<user>/git/IsaacLab/source/isaaclab
+> ```
+
+### Accept the NVIDIA EULA and make sure isaacsim import works:
+
+```bash
+python -c "import isaacsim"
+```
+
+### Run test using the test-script (should all pass)
+
+```bash
+bash scripts/run_isaaclab_test.sh
+# Or run individual test levels:
+python test/test_isaaclab_env.py --headless --env_id Isaac-Lift-Cube-Franka-v0 --test A
+```
+
+### Run training with Isaac Lab (not fully tested yet)
+
+```bash
+python train.py \
+    --config-name=train_diffusion_workspace.yaml \
+    task=isaaclab_lift_cube \
+    exp_name=isaaclab_test \
+    dataset_path=data/<your_dataset>
+```

--- a/manifeel/config/task/isaaclab_lift_cube.yaml
+++ b/manifeel/config/task/isaaclab_lift_cube.yaml
@@ -1,0 +1,25 @@
+name: isaaclab_lift_cube
+
+shape_meta: &shape_meta
+  # acceptable types: rgb, low_dim
+  obs:
+    state:
+      shape: [7]
+      type: low_dim
+  action:
+    shape: [8]  # 7 arm DOF + 1 gripper
+
+env_runner:
+  _target_: manifeel.env_runner.isaaclab_runner.IsaacLabRunner
+  shape_meta: ${shape_meta}
+  env_id: Isaac-Lift-Cube-Franka-v0
+  n_test: 10
+  n_test_vis: 2
+  test_start_seed: 100000
+  max_steps: 200
+  n_obs_steps: ${n_obs_steps}
+  n_action_steps: ${n_action_steps}
+  fps: 10
+  past_action: ${past_action_visible}
+  headless: true
+  device: cuda:0

--- a/manifeel/env_runner/isaaclab_runner.py
+++ b/manifeel/env_runner/isaaclab_runner.py
@@ -1,0 +1,151 @@
+#  Isaac Lab env_runner
+#  based on vistac_pih_runner.py
+
+from manifeel.gym_util.multistep_wrapper import MultiStepWrapper
+from manifeel.gym_util.video_recording_wrapper import VideoRecordingWrapper
+from manifeel.envs.isaaclab_env_wrapper import IsaacLabEnvWrapper
+
+from diffusion_policy.policy.base_image_policy import BaseImagePolicy
+from diffusion_policy.common.pytorch_util import dict_apply
+from diffusion_policy.env_runner.base_image_runner import BaseImageRunner
+import cv2
+import wandb
+import numpy as np
+import torch
+import collections
+import tqdm
+import time
+
+class IsaacLabRunner(BaseImageRunner):
+    def __init__(self,
+            output_dir: str,
+            shape_meta: dict,
+            env_id: str,
+            n_test=22,
+            n_test_vis=6,
+            test_start_seed=10000,
+            max_steps=200,
+            n_obs_steps=8,
+            n_action_steps=8,
+            fps=10,
+            crf=22,
+            past_action=False,
+            tqdm_interval_sec=5.0,
+            headless=True,
+            device='cuda:0',
+        ):
+        super().__init__(output_dir)
+
+        # Build Isaac Lab env config
+        isaaclab_cfg = {
+            'env_id': env_id,
+            'num_envs': n_test if n_test is not None else 10,
+            'headless': headless,
+            'device': device,
+            'shape_meta': shape_meta,
+        }
+
+        steps_per_render = max(10 // fps, 1)
+        env = MultiStepWrapper(
+                VideoRecordingWrapper(
+                        IsaacLabEnvWrapper(isaaclab_cfg),
+                        output_dir=output_dir,
+                        n_records=n_test_vis,
+                        fps=fps,
+                        crf=crf,
+                        file_paths=None,
+                        steps_per_render=steps_per_render
+                ),
+                n_obs_steps=n_obs_steps,
+                n_action_steps=n_action_steps,
+                max_episode_steps=max_steps
+        )
+
+        self.env = env
+        self.test_seed = test_start_seed
+        self.fps = fps
+        self.crf = crf
+        self.n_obs_steps = n_obs_steps
+        self.n_action_steps = n_action_steps
+        self.past_action = past_action
+        self.max_steps = max_steps
+        self.tqdm_interval_sec = tqdm_interval_sec
+
+    def run(self, policy: BaseImagePolicy):
+        device = policy.device
+        dtype = policy.dtype
+        env = self.env
+
+        # plan for rollout
+        n_envs = env.num_envs
+
+        print("Number of envs runner: ", n_envs)
+
+        # allocate data
+        all_video_paths = [None] * n_envs
+        all_rewards = [None] * n_envs
+
+        # start rollout
+        env.seed(self.test_seed)
+        obs = env.reset()
+        time.sleep(2)
+        # past_action = None
+        policy.reset()
+
+        pbar = tqdm.tqdm(total=self.max_steps, desc=f"Eval IsaacLabRunner",
+            leave=False, mininterval=self.tqdm_interval_sec)
+        done = False
+
+        while not done:
+            # create obs dict
+            np_obs_dict = dict(obs)
+
+            # device transfer
+            obs_dict = dict_apply(np_obs_dict,
+                lambda x: torch.from_numpy(x).to(
+                    device=device))
+
+            # run policy
+            with torch.no_grad():
+                action_dict = policy.predict_action(obs_dict)
+
+            # device_transfer
+            np_action_dict = dict_apply(action_dict,
+                lambda x: x.detach().to('cpu').numpy())
+
+            action = np_action_dict['action']
+
+            # step env
+            obs, reward, done, info = env.step(action)
+            done = np.all(done)
+
+            # update pbar
+            pbar.update(action.shape[1])
+        pbar.close()
+
+        all_rewards = env.get_rewards()
+        all_video_paths = env.render()
+        # clear out video buffer
+        _ = env.reset()
+
+        # log
+        max_rewards = collections.defaultdict(list)
+        log_data = dict()
+        for i in range(n_envs):
+            prefix = 'test/'
+            max_reward = np.max(all_rewards[i])
+            max_rewards[prefix].append(max_reward)
+
+            # visualize sim
+            video_path = all_video_paths[i]
+            if video_path is not None:
+                sim_video = wandb.Video(video_path)
+                log_data[prefix+f'sim_video_{i}'] = sim_video
+
+        # log aggregate metrics
+        for prefix, value in max_rewards.items():
+            name = prefix+'mean_score'
+            value = np.mean(value)
+            log_data[name] = value
+
+        return log_data

--- a/manifeel/envs/isaaclab_env_wrapper.py
+++ b/manifeel/envs/isaaclab_env_wrapper.py
@@ -1,0 +1,239 @@
+from gym import spaces
+
+import torch
+import numpy as np
+import cv2
+import random
+import os
+import sys
+
+# Should point to Isaac Lab source path, must come before site-packages so the git source package
+# takes priority over the pip launcher.
+_ISAACLAB_SOURCE = os.environ.get(
+    "ISAACLAB_SOURCE", # set env var to point to path like "/scratch/gilbreth/.../git/IsaacLab/source/isaaclab"
+)
+if _ISAACLAB_SOURCE not in sys.path:
+    sys.path.insert(0, _ISAACLAB_SOURCE)
+
+class IsaacLabEnvWrapper():
+
+    metadata = {"render.modes": ["rgb_array"], "video.frames_per_second": 10}
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.render_cache = []
+
+        # obtain task observation keys from the shape_meta
+        shape_meta = self.cfg['shape_meta']
+        rgb_keys = list()
+        lowdim_keys = list()
+        obs_shape_meta = shape_meta['obs']
+        for key, attr in obs_shape_meta.items():
+            type = attr.get('type', 'low_dim')
+            if type == 'rgb':
+                rgb_keys.append(key)
+            elif type == 'low_dim':
+                lowdim_keys.append(key)
+
+        self.task_obs_keys = rgb_keys + lowdim_keys
+        self.vision_obs_keys = list(rgb_keys)
+        # this case handles no-vision setting
+        if not self.vision_obs_keys:
+            self.vision_obs_keys = ['front']
+
+        self._start_task(self.cfg)
+
+    def _start_task(self, cfg):
+        env_id = cfg['env_id']
+        num_envs = cfg.get('num_envs', 1)
+        headless = cfg.get('headless', True)
+        device = cfg.get('device', 'cuda:0')
+
+        # bootstrap isaacsim kernel (initializes omni.kit path)
+        import isaacsim  # noqa: F401
+
+        # Start AppLauncher to initialize full Omniverse runtime
+        # (must be done before importing any isaaclab.* modules)
+        # Only start if not already running
+        if not getattr(IsaacLabEnvWrapper, '_app_launcher', None):
+            from isaaclab.app import AppLauncher
+            launcher_cfg = {"headless": headless}
+            IsaacLabEnvWrapper._app_launcher = AppLauncher(launcher_cfg)
+            IsaacLabEnvWrapper._sim_app = IsaacLabEnvWrapper._app_launcher.app
+
+        # Register all Isaac Lab task environments
+        import isaaclab_tasks  # noqa: F401
+
+        # Create env using Isaac Lab's parse_env_cfg + ManagerBasedRLEnv
+        # (gymnasium.make() does not properly handle the env_cfg_entry_point kwarg)
+        from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
+        from isaaclab.envs import ManagerBasedRLEnv
+
+        env_cfg = parse_env_cfg(env_id, device=device, num_envs=num_envs)
+        self.envs = ManagerBasedRLEnv(cfg=env_cfg)
+        self._num_envs = num_envs
+
+    @property
+    def observation_space(self):
+        obs_space = self._build_observation_space()
+        return obs_space
+
+    @property
+    def action_space(self):
+        # Convert gymnasium.spaces to gym.spaces
+        # Isaac Lab action_space.shape = (num_envs, action_dim); strip num_envs
+        gym_action_space = self.envs.action_space
+        if hasattr(gym_action_space, 'shape'):
+            action_shape = gym_action_space.shape[1:] if len(gym_action_space.shape) > 1 else gym_action_space.shape
+            return spaces.Box(
+                low=np.float32(-1.0), high=np.float32(1.0),
+                shape=action_shape,
+                dtype=np.float32
+            )
+        return gym_action_space
+
+    @property
+    def num_envs(self) -> int:
+        """Get the number of environments."""
+        return self._num_envs
+
+    def seed(self, seed=None):
+        if seed is None:
+            seed = np.random.randint(0, 25536)
+        self._seed = seed
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        os.environ['PYTHONHASHSEED'] = str(seed)
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        return seed
+
+    def step(self, actions):
+        actions = torch.from_numpy(actions).to(dtype=torch.float32)
+        # Isaac Lab returns (obs, reward, terminated, truncated, info)
+        obs, reward, terminated, truncated, info = self.envs.step(actions)
+
+        obs = self._transform_obs_data(obs)
+        self.render_cache = obs
+        obs = self._apply_obs_by_keys(obs)
+
+        # Merge terminated | truncated -> done (gym API compatibility)
+        done = (terminated | truncated)
+        if isinstance(done, torch.Tensor):
+            done = done.cpu().numpy().astype(np.int64)
+        else:
+            done = np.array(done, dtype=np.int64)
+
+        if isinstance(reward, torch.Tensor):
+            reward = reward.cpu().numpy()
+        else:
+            reward = np.array(reward)
+
+        # Convert info tensors to numpy
+        np_info = {}
+        for key, value in info.items():
+            if isinstance(value, torch.Tensor):
+                np_info[key] = value.cpu().numpy()
+            else:
+                np_info[key] = value
+
+        return obs, reward, done, np_info
+
+    def reset(self):
+        # Isaac Lab returns (obs, info)
+        obs, info = self.envs.reset()
+
+        obs = self._transform_obs_data(obs)
+        self.render_cache = obs
+        obs = self._apply_obs_by_keys(obs)
+        return obs
+
+    def render(self, mode="rgb_array"):
+        if self.render_cache is None:
+            raise RuntimeError('Must run reset or step before render.')
+        img_list = []
+
+        for obs_view in self.vision_obs_keys:
+            if obs_view in self.render_cache:
+                imgs = self.render_cache[obs_view]  # (num_envs, 3, H, W)
+                imgs = np.moveaxis(imgs, 1, -1)      # (num_envs, H, W, 3)
+                imgs = (imgs * 255).astype(np.uint8) if imgs.max() <= 1.0 else imgs.astype(np.uint8)
+                img_list.append(imgs)
+
+        if img_list:
+            return np.concatenate(img_list, axis=2)
+        else:
+            # render placeholder frame per env when no vision obs cached
+            frames = []
+            for i in range(self.num_envs):
+                frame = np.zeros((128, 128, 3), dtype=np.uint8)
+                frames.append(frame)
+            return np.stack(frames, axis=0)
+
+    def _transform_obs_data(self, obs):
+        tf_obs = dict()
+
+        if isinstance(obs, dict):
+            for key, value in obs.items():
+                if isinstance(value, torch.Tensor):
+                    tf_obs[key] = value.cpu().numpy()
+                else:
+                    tf_obs[key] = np.array(value)
+
+                # Check if the last dimension has size 3
+                # check if it is the image data
+                # (num_envs, H, W, 3) -> (num_envs, 3, H, W)
+                if len(tf_obs[key].shape) >= 3 and tf_obs[key].shape[-1] == 3:
+                    tf_obs[key] = np.moveaxis(tf_obs[key], -1, 1)
+        else:
+            # If obs is a flat tensor (e.g. state-only env)
+            if isinstance(obs, torch.Tensor):
+                obs_np = obs.cpu().numpy()
+            else:
+                obs_np = np.array(obs)
+            tf_obs['flat_obs'] = obs_np
+
+        # Construct state from policy observation if available
+        if 'state' not in tf_obs:
+            if 'policy' in tf_obs:
+                # Isaac Lab often puts state obs under 'policy' key
+                policy_obs = tf_obs.pop('policy')
+                # Extract EE pose (first 7 dims: pos[3] + quat[4])
+                state = policy_obs[:, :7]
+                tf_obs['state'] = state
+            elif 'flat_obs' in tf_obs:
+                state = tf_obs['flat_obs'][:, :7]
+                tf_obs['state'] = state
+
+        return tf_obs
+
+    def _apply_obs_by_keys(self, obs):
+        task_obs = {key: obs[key] for key in self.task_obs_keys if key in obs}
+        return task_obs
+
+    def _build_observation_space(self):
+        updated_observation_space = {}
+
+        for key in self.task_obs_keys:
+            shape_meta = self.cfg['shape_meta']['obs']
+            if key in shape_meta:
+                shape = tuple(shape_meta[key]['shape'])
+                obs_type = shape_meta[key].get('type', 'low_dim')
+                if obs_type == 'rgb':
+                    updated_observation_space[key] = spaces.Box(
+                        low=np.float32(-np.inf), high=np.float32(np.inf),
+                        shape=shape,
+                        dtype=np.float32
+                    )
+                else:
+                    updated_observation_space[key] = spaces.Box(
+                        low=np.float32(-np.inf), high=np.float32(np.inf),
+                        shape=shape,
+                        dtype=np.float32
+                    )
+
+        return spaces.Dict(updated_observation_space)
+
+    def close(self):
+        self.envs.close()

--- a/scripts/run_isaaclab_test.sh
+++ b/scripts/run_isaaclab_test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Test script for Isaac Lab environment
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Activate isaaclab conda environment
+eval "$(conda shell.bash hook)"
+conda activate /scratch/gilbreth/halchaer/conda/envs/isaaclab
+
+# Isaac Lab source path: the git-cloned Isaac Lab repo source packages
+# (the pip isaaclab wheel is a launcher stub, actual framework lives in the git repo)
+export ISAACLAB_SOURCE=/scratch/gilbreth/halchaer/git/IsaacLab/source/isaaclab
+
+cd "$PROJECT_DIR"
+
+echo "Running Isaac Lab environment tests..."
+python test/test_isaaclab_env.py --headless "$@"

--- a/test/test_isaaclab_env.py
+++ b/test/test_isaaclab_env.py
@@ -1,0 +1,244 @@
+"""
+Test script for Isaac Lab environment wrapper and runner.
+
+Three test levels:
+  A (Wrapper): Instantiate wrapper, reset, random steps, verify obs shapes
+  B (Full stack): Wrapper + VideoRecording + MultiStep, random rollout, verify videos + rewards
+  C (Runner): IsaacLabRunner with mock random policy, verify log_data keys
+"""
+
+import argparse
+import numpy as np
+import torch
+import os
+import sys
+
+def test_wrapper(env_id, num_envs, headless, device):
+    """Test A: Raw IsaacLabEnvWrapper."""
+    from manifeel.envs.isaaclab_env_wrapper import IsaacLabEnvWrapper
+
+    print("=" * 60)
+    print("Test A: IsaacLabEnvWrapper")
+    print("=" * 60)
+
+    cfg = {
+        'env_id': env_id,
+        'num_envs': num_envs,
+        'headless': headless,
+        'device': device,
+        'shape_meta': {
+            'obs': {
+                'state': {'shape': [7], 'type': 'low_dim'},
+            },
+            'action': {'shape': [7]},
+        },
+    }
+
+    env = IsaacLabEnvWrapper(cfg)
+
+    # Check spaces
+    print(f"Observation space: {env.observation_space}")
+    print(f"Action space: {env.action_space}")
+    print(f"Num envs: {env.num_envs}")
+    assert env.num_envs == num_envs
+
+    # Reset
+    obs = env.reset()
+    print(f"Reset obs keys: {obs.keys()}")
+    assert 'state' in obs, "Missing 'state' key in obs"
+    assert obs['state'].shape == (num_envs, 7), f"Expected state shape ({num_envs}, 7), got {obs['state'].shape}"
+
+    # Step with random actions
+    for step_i in range(5):
+        random_actions = 2.0 * np.random.rand(num_envs, env.action_space.shape[0]) - 1.0
+        obs, reward, done, info = env.step(random_actions)
+        assert 'state' in obs
+        assert obs['state'].shape == (num_envs, 7)
+        assert reward.shape == (num_envs,), f"Reward shape mismatch: {reward.shape}"
+        assert done.shape == (num_envs,), f"Done shape mismatch: {done.shape}"
+        print(f"  Step {step_i}: state shape={obs['state'].shape}, reward shape={reward.shape}")
+
+    # Render
+    frames = env.render()
+    print(f"Render shape: {frames.shape}")
+    assert frames.dtype == np.uint8
+
+    env.close()
+    print("Test A PASSED\n")
+
+
+def test_full_stack(env_id, num_envs, headless, device, output_dir):
+    """Test B: Wrapper + VideoRecordingWrapper + MultiStepWrapper."""
+    from manifeel.envs.isaaclab_env_wrapper import IsaacLabEnvWrapper
+    from manifeel.gym_util.video_recording_wrapper import VideoRecordingWrapper
+    from manifeel.gym_util.multistep_wrapper import MultiStepWrapper
+
+    print("=" * 60)
+    print("Test B: Full Stack (MultiStep + VideoRecording + Wrapper)")
+    print("=" * 60)
+
+    n_obs_steps = 3
+    n_action_steps = 5
+    max_steps = 50
+    fps = 10
+    crf = 22
+    n_test_vis = min(2, num_envs)
+    steps_per_render = max(10 // fps, 1)
+
+    cfg = {
+        'env_id': env_id,
+        'num_envs': num_envs,
+        'headless': headless,
+        'device': device,
+        'shape_meta': {
+            'obs': {
+                'state': {'shape': [7], 'type': 'low_dim'},
+            },
+            'action': {'shape': [7]},
+        },
+    }
+
+    env = MultiStepWrapper(
+            VideoRecordingWrapper(
+                    IsaacLabEnvWrapper(cfg),
+                    output_dir=output_dir,
+                    n_records=n_test_vis,
+                    fps=fps,
+                    crf=crf,
+                    file_paths=None,
+                    steps_per_render=steps_per_render
+            ),
+            n_obs_steps=n_obs_steps,
+            n_action_steps=n_action_steps,
+            max_episode_steps=max_steps
+    )
+
+    print(f"Obs space: {env.observation_space}")
+    print(f"Action space: {env.action_space}")
+    print(f"Num envs: {env.num_envs}")
+
+    obs = env.reset()
+    print(f"Reset obs keys: {obs.keys()}")
+    assert 'state' in obs
+    # shape should be (num_envs, n_obs_steps, 7)
+    print(f"  state shape: {obs['state'].shape}")
+
+    done = False
+    step_count = 0
+    action_dim = env.action_space.shape[1]  # MultiStepWrapper: (n_action_steps, action_dim)
+    while not done:
+        random_actions = 2.0 * np.random.rand(num_envs, n_action_steps, action_dim) - 1.0
+        obs, reward, done, info = env.step(random_actions)
+        done = np.all(done)
+        step_count += n_action_steps
+
+    print(f"Rollout completed in {step_count} action steps")
+
+    all_rewards = env.get_rewards()
+    all_video_paths = env.render()
+    print(f"Rewards shape: {all_rewards.shape}")
+    print(f"Video paths: {all_video_paths}")
+
+    # Verify videos exist
+    video_count = sum(1 for p in all_video_paths if p is not None)
+    print(f"Videos recorded: {video_count}")
+
+    # Clear out video buffer
+    _ = env.reset()
+
+    print("Test B PASSED\n")
+
+
+def test_runner(env_id, num_envs, headless, device, output_dir):
+    """Test C: IsaacLabRunner with mock random policy."""
+    from manifeel.env_runner.isaaclab_runner import IsaacLabRunner
+
+    print("=" * 60)
+    print("Test C: IsaacLabRunner with Mock Policy")
+    print("=" * 60)
+
+    class MockRandomPolicy:
+        """Mock policy that returns random actions."""
+        def __init__(self, action_dim, n_action_steps, device='cpu'):
+            self.device = torch.device(device)
+            self.dtype = torch.float32
+            self.action_dim = action_dim
+            self.n_action_steps = n_action_steps
+
+        def reset(self):
+            pass
+
+        def predict_action(self, obs_dict):
+            # Get batch size from any obs key
+            for key, value in obs_dict.items():
+                batch_size = value.shape[0]
+                break
+            action = torch.randn(batch_size, self.n_action_steps, self.action_dim,
+                                 device=self.device, dtype=self.dtype)
+            return {'action': action}
+
+    n_obs_steps = 3
+    n_action_steps = 5
+
+    runner = IsaacLabRunner(
+        output_dir=output_dir,
+        shape_meta={
+            'obs': {
+                'state': {'shape': [7], 'type': 'low_dim'},
+            },
+            'action': {'shape': [8]},
+        },
+        env_id=env_id,
+        n_test=num_envs,
+        n_test_vis=min(2, num_envs),
+        test_start_seed=10000,
+        max_steps=50,
+        n_obs_steps=n_obs_steps,
+        n_action_steps=n_action_steps,
+        fps=10,
+        crf=22,
+        past_action=False,
+        headless=headless,
+        device=device,
+    )
+
+    policy = MockRandomPolicy(action_dim=8, n_action_steps=n_action_steps, device='cpu')
+    log_data = runner.run(policy)
+
+    print(f"log_data keys: {list(log_data.keys())}")
+    assert 'test/mean_score' in log_data, "Missing 'test/mean_score' in log_data"
+    print(f"test/mean_score = {log_data['test/mean_score']}")
+
+    # Check for video entries
+    video_keys = [k for k in log_data.keys() if 'video' in k]
+    print(f"Video log entries: {video_keys}")
+
+    print("Test C PASSED\n")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Test Isaac Lab environment integration')
+    parser.add_argument('--env_id', type=str, default='Isaac-Lift-Cube-Franka-v0')
+    parser.add_argument('--num_envs', type=int, default=4)
+    parser.add_argument('--headless', action='store_true')
+    parser.add_argument('--device', type=str, default='cuda:0')
+    parser.add_argument('--output_dir', type=str, default='./test_output')
+    parser.add_argument('--test', type=str, default='all',
+                        choices=['all', 'A', 'B', 'C'],
+                        help='Which test level to run')
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    if args.test in ('all', 'A'):
+        test_wrapper(args.env_id, args.num_envs, args.headless, args.device)
+
+    if args.test in ('all', 'B'):
+        test_full_stack(args.env_id, args.num_envs, args.headless, args.device, args.output_dir)
+
+    if args.test in ('all', 'C'):
+        test_runner(args.env_id, args.num_envs, args.headless, args.device, args.output_dir)
+
+    print("=" * 60)
+    print("ALL TESTS PASSED")
+    print("=" * 60)


### PR DESCRIPTION
Experimental PR for getting env_runner Isaac lab support

Note: to replicate, you may need to follow the steps I added in `IsaacLab_setup_documentation.md`, basic steps to install Isaac Lab, if you do not have it installed already with the Nvidia Omniverse setup. It requires python **3.10**, incompatible with python 3.8, so you have to make a 3.10 environment and re-install the packages that manifeel requires.

**`manifeel/envs/isaaclab_env_wrapper.py`:**

  - Starts up the Isaac Sim runtime (Isaac Lab needs a full Omniverse app launched before anything else)
  - Can creates N parallel environments
  - Translates Isaac Lab's outputs (GPU tensors, 5-tuple step returns, gymnasium spaces) into the format the rest of ManiFeel expects (numpy arrays, 4-tuple returns, gym spaces)

**`manifeel/env_runner/isaaclab_runner.py`:**

The equivalent of vistac_pih_runner.py but for Isaac Lab. We can call it the same way it already gets used in manifeel, like runner_log = env_runner.run(policy).

It handles seeding environments, running the policy for N rollout episodes in parallel, collecting success/failure outcomes, recording videos for visualization, and returning a log_data dict with test/mean_score. Because it inherits from the same BaseImageRunner base class and returns the same dict format, the training workspace train_diffusion_unet_image_workspace.py should be able to use it without changes

**`manifeel/config/task/isaaclab_lift_cube.yaml`:**

  Config for which environment to use (example Isaac-Lift-Cube-Franka-v0, the simplest available Isaac Lab task), how many test rollouts to run, what the observation/action shapes are, etc.

**Test scripts `test/test_isaaclab_env.py` + `scripts/run_isaaclab_test.sh `:**

These can be removed once the isaaclab envrunner is fully integrated

Has three tests:
  A: Does the wrapper start up, reset, and step without crashing? Do shapes match what we said?
  B: Does the full stack (wrapper + video recorder + temporal windowing) work together?
  C: Does the runner work end-to-end with a policy?

Test A gives output showing correct observation shapes

Test B produces a valid output like this:
```
  Action space: Box(-1.0, 1.0, (5, 8), float32)
  Reset obs keys: dict_keys(['state'])
    state shape: (4, 3, 7)
  Rollout completed in 50 action steps
  Rewards shape: (4, 50)
  Video paths: ['/scratch/.../test_output/media/97yexw3o.mp4',
                '/scratch/.../test_output/media/ij74ujw3.mp4', None, None]
  Videos recorded: 2
  Test B PASSED
```

  Test C produces an output like this:
```
  log_data keys: ['test/sim_video_0', 'test/sim_video_1', 'test/mean_score']
  test/mean_score = 0.331...
  Test C PASSED
```

The shapes match the config (state: (4 envs, 3 obs steps, 7 dims), action: (5 steps, 8 dims))
test/mean_score is the same key the training workspace reads at line 224




**What was NOT tested:**

  - A real trained policy was not run through it (only a MockRandomPolicy that outputs random actions).
  - For now I limited testing to a simpler environment, so the Isaac Lab environment used (Lift-Cube-Franka-v0) is not ManiFeel's actual hand+arm environment. 